### PR TITLE
'Close' SVG shrinking fix, added extra click listener to FIleTab div

### DIFF
--- a/src/components/fileTab/index.js
+++ b/src/components/fileTab/index.js
@@ -5,7 +5,9 @@ import './styles.css';
 
 export default ({ name, path, active, onClick }) => (
     <div className={`FileTab ${active && 'active'}`}>
-        <div className="title" children={name} onClick={() => onClick({ name, path })} />
+        <div className={`FileTab ${active && 'active'}`} onClick={() => onClick({ name, path })}>
+            <div className="title" children={name} onClick={() => onClick({ name, path })} />
+        </div>
         {active && <Icon name="close" className="icon" onClick={() => Action.closeFile(path)} />}
     </div>
 );

--- a/src/components/fileTab/styles.css
+++ b/src/components/fileTab/styles.css
@@ -1,6 +1,6 @@
 .FileTab {
     cursor: pointer;
-    width: 100px;
+    width: auto;
     height: inherit;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
### 1. Shrinking Fix
FileTab width was only 100px, and the longer file names were making the 'Close' svg *really* small, too small to click. Made the `.FileTab` class width `auto` instead to compensate. Not quite as uniform in width, but no more svg shrinking.

###  2. Extra Click Listener

Clicking the FileTab div would do nothing unless you clicked the actual filename text, so added the event listener to a container div also for a little bit larger click target

